### PR TITLE
Removes PHP scope from package jawee/atom-typo3#3

### DIFF
--- a/grammars/fluid.cson
+++ b/grammars/fluid.cson
@@ -1,12 +1,11 @@
 'name': 'Fluid'
-'scopeName': 'text.html.php'
+'scopeName': 'text.html'
 'fileTypes': [
   'html'
   'htm'
   'shtml'
   'xhtml'
   'phtml'
-  'php'
   'inc'
   'tmpl'
   'tpl'


### PR DESCRIPTION
because of syntax highlight conflict with package language-php